### PR TITLE
add support for providers specified in environment variables

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -37,10 +37,10 @@
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594",
-                "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"
+                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
+                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
             ],
-            "version": "==20.2.0"
+            "version": "==20.3.0"
         },
         "bleach": {
             "hashes": [
@@ -51,10 +51,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
-                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
             ],
-            "version": "==2020.6.20"
+            "version": "==2020.12.5"
         },
         "chardet": {
             "hashes": [
@@ -111,11 +111,11 @@
         },
         "coveralls": {
             "hashes": [
-                "sha256:4430b862baabb3cf090d36d84d331966615e4288d8a8c5957e0fd456d0dd8bd6",
-                "sha256:b3b60c17b03a0dee61952a91aed6f131e0b2ac8bd5da909389c53137811409e1"
+                "sha256:2301a19500b06649d2ec4f2858f9c69638d7699a4c63027c5d53daba666147cc",
+                "sha256:b990ba1f7bc4288e63340be0433698c1efe8217f78c689d254c2540af3d38617"
             ],
             "index": "pypi",
-            "version": "==2.1.2"
+            "version": "==2.2.0"
         },
         "docopt": {
             "hashes": [
@@ -147,18 +147,18 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da",
-                "sha256:cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3"
+                "sha256:5c5a2720817414a6c41f0a49993908068243ae02c1635a228126519b509c8aed",
+                "sha256:bf792d480abbd5eda85794e4afb09dd538393f7d6e6ffef6e9f03d2014cf9450"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==2.0.0"
+            "version": "==3.3.0"
         },
         "keyring": {
             "hashes": [
-                "sha256:4e34ea2fdec90c1c43d6610b5a5fafa1b9097db1802948e90caf5763974b8f8d",
-                "sha256:9aeadd006a852b78f4b4ef7c7556c2774d2432bbef8ee538a3e9089ac8b11466"
+                "sha256:12de23258a95f3b13e5b167f7a641a878e91eab8ef16fafc077720a95e6115bb",
+                "sha256:207bd66f2a9881c835dad653da04e196c678bf104f8252141d2d3c4f31051579"
             ],
-            "version": "==21.4.0"
+            "version": "==21.5.0"
         },
         "mccabe": {
             "hashes": [
@@ -176,10 +176,10 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
-                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
+                "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858",
+                "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"
             ],
-            "version": "==20.4"
+            "version": "==20.8"
         },
         "pkginfo": {
             "hashes": [
@@ -197,10 +197,10 @@
         },
         "py": {
             "hashes": [
-                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
-                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
             ],
-            "version": "==1.9.0"
+            "version": "==1.10.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -218,10 +218,10 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:381985fcc551eb9d37c52088a32914e00517e57f4a21609f48141ba08e193fa0",
-                "sha256:88a0bbcd659fcb9573703957c6b9cff9fab7295e6e76db54c9d00ae42df32773"
+                "sha256:ccf3acacf3782cbed4a989426012f1c535c9a90d3a7fc3f16d231b9372d2b716",
+                "sha256:f275b6c0909e5dafd2d6269a656aa90fa58ebf4a74f8fcf9053195d226b24a08"
             ],
-            "version": "==2.7.2"
+            "version": "==2.7.3"
         },
         "pyparsing": {
             "hashes": [
@@ -247,10 +247,10 @@
         },
         "requests": {
             "hashes": [
-                "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
-                "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"
+                "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8",
+                "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"
             ],
-            "version": "==2.24.0"
+            "version": "==2.25.0"
         },
         "requests-toolbelt": {
             "hashes": [
@@ -275,10 +275,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:9ad44aaf0fc3697c06f6e05c7cf025dd66bc7bcb7613c66d85f4464c47ac8fad",
-                "sha256:ef54779f1c09f346b2b5a8e5c61f96fbcb639929e640e59f8cf810794f406432"
+                "sha256:38b658a3e4ecf9b4f6f8ff75ca16221ae3378b2e175d846b6b33ea3a20852cf5",
+                "sha256:d4f413aecb61c9779888c64ddf0c62910ad56dcbe857d8922bb505d4dbff0df1"
             ],
-            "version": "==4.51.0"
+            "version": "==4.54.1"
         },
         "twine": {
             "hashes": [
@@ -288,12 +288,21 @@
             "index": "pypi",
             "version": "==3.2.0"
         },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
+                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
+                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==3.7.4.3"
+        },
         "urllib3": {
             "hashes": [
-                "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
-                "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
+                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
+                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
             ],
-            "version": "==1.25.11"
+            "version": "==1.26.2"
         },
         "wcwidth": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='yamz',
-      version='0.3.0a',
+      version='0.3.0a1',
       description='An easy way to manage environment specific configuration',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tests/test_import_resolvers.py
+++ b/tests/test_import_resolvers.py
@@ -1,0 +1,40 @@
+import unittest
+
+from yamz.providers.default import JsonProvider
+from yamz.utils import import_resolver, safe_import_resolver
+
+
+class ImportResolverTestCase(unittest.TestCase):
+    def test_import_resolver_correctly_returns_provider_class(self):
+        klass = None
+        import_failed = False
+        try:
+            klass = import_resolver('yamz.providers.default.JsonProvider')
+        except ImportError:
+            import_failed = True
+
+        self.assertFalse(import_failed)
+        self.assertEqual(klass, JsonProvider)
+
+    def test_safe_import_resolver_correctly_returns_provider_class(self):
+        klass = None
+        import_failed = False
+        try:
+            klass = safe_import_resolver('yamz.providers.default.JsonProvider')
+        except ImportError:
+            import_failed = True
+
+        self.assertFalse(import_failed)
+        self.assertEqual(klass, JsonProvider)
+
+    def test_import_resolver_raises_import_error_on_import_failure(self):
+        with self.assertRaises(ImportError):
+            import_resolver('path.to.BogusProvider')
+
+    def test_safe_import_resolver_returns_none_on_import_failure(self):
+        klass = safe_import_resolver('path.to.BogusProvider')
+        self.assertIsNone(klass)
+
+    def test_import_resolver_assertion_fails_when_attribute_not_exist_in_module(self):
+        with self.assertRaises(TypeError):
+            import_resolver('yamz.providers.default.BogusProvider')

--- a/yamz/cli.py
+++ b/yamz/cli.py
@@ -1,31 +1,20 @@
-import importlib
-from typing import Type
+import os
 
 from yamz import Yamz
 from yamz.errors import YamzEnvironmentError
 from yamz.logger import logger
-from yamz.providers.base import BaseProvider
-
-
-def import_resolver(module_path: str) -> Type[BaseProvider]:
-    """
-    Takes a string reference to a class and returns
-    an actual Python class.
-    """
-
-    split_path = module_path.split('.')
-    klass = split_path[-1]
-    package = '.'.join(split_path[:-1])
-    module = importlib.import_module(package)
-    provider_class = getattr(module, klass)
-    assert issubclass(provider_class, BaseProvider)
-    return provider_class
+from yamz.utils import safe_import_resolver
 
 
 def main(action: str, key: str, data: str, environment: str, path: str = None, provider: str = None):
     config = {'path': path}
-    if provider:
-        provider_class = import_resolver(provider)
+
+    provider_ref = provider or os.getenv('YAMZ_DEFAULT_PROVIDER')
+    provider_class = None
+    if provider_ref:
+        provider_class = safe_import_resolver(provider_ref)
+
+    if provider_class:
         config.update({'provider': provider_class})
 
     yamz = Yamz(**config)

--- a/yamz/logger.py
+++ b/yamz/logger.py
@@ -1,6 +1,6 @@
 import logging
 
-FORMAT = '%(name)s - %(message)s'
+FORMAT = '%(name)s (%(levelname)s): %(message)s'
 
 logging.basicConfig(format=FORMAT)
 

--- a/yamz/utils.py
+++ b/yamz/utils.py
@@ -1,0 +1,28 @@
+import importlib
+from typing import Optional, Type
+
+from yamz.logger import logger
+from yamz.providers.base import BaseProvider
+
+
+def import_resolver(module_path: str) -> Type[BaseProvider]:
+    """
+    Takes a string reference to a class and returns
+    an actual Python class.
+    """
+
+    split_path = module_path.split('.')
+    klass = split_path[-1]
+    package = '.'.join(split_path[:-1])
+    module = importlib.import_module(package)
+    provider_class = getattr(module, klass, None)
+    assert issubclass(provider_class, BaseProvider)
+    return provider_class
+
+
+def safe_import_resolver(module_path: str) -> Optional[Type[BaseProvider]]:
+    try:
+        return import_resolver(module_path)
+    except ImportError:
+        logger.warning("Unable to import provider '%s', falling back to default." % module_path)
+        return None


### PR DESCRIPTION
Yamz CLI now looks for `YAMZ_DEFAULT_PROVIDER` and uses it when available. This allows you to provide overrides on a per project bases.

In an `.env` file with `YAMZ_DEFAULT_PROVIDER=path.to.Provider`:
`pipenv run yamz read --key=mykey --env=prod`

Or inline:
`YAMZ_DEFAULT_PROVIDER=path.to.Provider yamz read --key=mykey --env=prov`